### PR TITLE
Allow 10.162.136.0/24 on homes recipe

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,3 +7,12 @@ AllCops:
 
 Style/NumericLiteralPrefix:
   EnforcedOctalStyle: zero_only
+
+Metrics/LineLength:
+  Max: 120
+
+Style/IfUnlessModifier:
+  MaxLineLength: 120
+
+Style/WhileUntilModifier:
+  MaxLineLength: 120

--- a/recipes/homes.rb
+++ b/recipes/homes.rb
@@ -17,6 +17,7 @@
 # limitations under the License.
 #
 
+node.default['firewall']['nfs']['range']['4'] = %w(10.162.136.0/24)
 include_recipe 'osl-nfs::default'
 
 directory '/data/homes/' do

--- a/test/integration/homes/serverspec/homes_spec.rb
+++ b/test/integration/homes/serverspec/homes_spec.rb
@@ -6,7 +6,16 @@ end
 
 describe file('/etc/exports') do
   its(:content) do
-    should eq('/data/homes/ 10.162.136.0/24(rw,sync,mountpoint,' \
-      'no_root_squash)' + "\n")
+    should eq("/data/homes/ 10.162.136.0/24(rw,sync,mountpoint,no_root_squash)\n")
+  end
+end
+
+describe iptables do
+  %w(tcp udp).each do |proto|
+    %w(111 2049 32765 32766 32767 32768).each do |port|
+      it do
+        should have_rule("-A nfs -s 10.162.136.0/24 -p #{proto} -m #{proto} --dport #{port} -j ACCEPT")
+      end
+    end
   end
 end


### PR DESCRIPTION
With the updates in osuosl-cookbooks/firewall#120, this requires us to set the
network to allow for NFS on nfs-homes.

In addition, I've cleaned up the tests and a few other things.