### PR TITLE
Add test for port 32769

### DIFF
--- a/test/integration/homes/serverspec/homes_spec.rb
+++ b/test/integration/homes/serverspec/homes_spec.rb
@@ -12,7 +12,7 @@ end
 
 describe iptables do
   %w(tcp udp).each do |proto|
-    %w(111 2049 32765 32766 32767 32768).each do |port|
+    %w(111 2049 32765 32766 32767 32768 32769).each do |port|
       it do
         should have_rule("-A nfs -s 10.162.136.0/24 -p #{proto} -m #{proto} --dport #{port} -j ACCEPT")
       end


### PR DESCRIPTION
This will add a missing test for the ip table rules for port 32769. I'm assuming this can
be merged without a bump.