### PR TITLE
Properly set lockd port on CentOS 7

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,3 +16,6 @@ Style/IfUnlessModifier:
 
 Style/WhileUntilModifier:
   MaxLineLength: 120
+
+Metrics/BlockLength:
+  Max: 35

--- a/Berksfile
+++ b/Berksfile
@@ -1,5 +1,6 @@
 source 'https://supermarket.chef.io'
 
+cookbook 'base', git: 'git@github.com:osuosl-cookbooks/base'
 cookbook 'firewall', git: 'git@github.com:osuosl-cookbooks/firewall'
 
 metadata

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,6 +8,8 @@ description      'Installs/Configures osl-nfs'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.2.3'
 
+depends          'base'
+depends          'kernel-modules'
 depends          'nfs', '~> 2.4.1'
 depends          'line', '< 2.0.0'
 depends          'firewall'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -16,6 +16,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+include_recipe 'kernel-modules'
+
+kernel_module 'lockd' do
+  onboot true
+  options %w(nlm_tcpport=32768 nlm_udpport=32768)
+  only_if { node['platform_version'].to_i >= 7 }
+end
+
+sysctl_param 'fs.nfs.nlm_tcpport' do
+  value '32768'
+  notifies :restart, "service[#{node['nfs']['service']['server']}]"
+  only_if { node['platform_version'].to_i >= 7 }
+end
+
+sysctl_param 'fs.nfs.nlm_udpport' do
+  value '32768'
+  notifies :restart, "service[#{node['nfs']['service']['server']}]"
+  only_if { node['platform_version'].to_i >= 7 }
+end
 
 include_recipe 'nfs::server'
 include_recipe 'firewall::nfs'

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -14,6 +14,33 @@ describe 'osl-nfs::default' do
           expect(chef_run).to include_recipe(r)
         end
       end
+      case p
+      when CENTOS_7
+        it do
+          expect(chef_run).to load_kernel_module('lockd')
+            .with(
+              onboot: true,
+              options: %w(nlm_tcpport=32768 nlm_udpport=32768)
+            )
+        end
+        %w(tcp udp).each do |proto|
+          it do
+            expect(chef_run).to apply_sysctl_param("fs.nfs.nlm_#{proto}port").with(value: '32768')
+          end
+          it do
+            expect(chef_run.sysctl_param("fs.nfs.nlm_#{proto}port")).to notify('service[nfs-server]')
+          end
+        end
+      when CENTOS_6
+        it do
+          expect(chef_run).to_not load_kernel_module('lockd')
+        end
+        %w(tcp udp).each do |proto|
+          it do
+            expect(chef_run).to_not apply_sysctl_param("fs.nfs.nlm_#{proto}port").with(value: '32768')
+          end
+        end
+      end
     end
   end
 end

--- a/test/integration/helpers/serverspec/shared_examples.rb
+++ b/test/integration/helpers/serverspec/shared_examples.rb
@@ -22,4 +22,17 @@ shared_examples 'nfs' do
       it { should be_running }
     end
   end
+  describe command('rpcinfo -p localhost') do
+    [
+      %w(111 portmapper),
+      %w(32765 status),
+      %w(32767 mountd),
+      %w(2049 nfs),
+      %w(2049 nfs_acl),
+      %w(32768 nlockmgr)
+    ].each do |port, service|
+      its(:stdout) { should match(/tcp.*#{port}.*#{service}$/) }
+      its(:stdout) { should match(/udp.*#{port}.*#{service}$/) }
+    end
+  end
 end


### PR DESCRIPTION
The upstream cookbook doesn't seem to properly set the lockd port to what we
want for CentOS 7. It looks as though upstream changed it so that you need to
use either/both setting the kernel module and the sysctl setting. For now, let's
set both. We can't reload the module if it's already in use but if we can change
the port of the running system with sysctl as long as we restart the nfs server
after changing that.

I also improved the ServerSpec tests to check to make sure the ports for the
various services are running on the ports we expect. Otherwise we run into
problems with clients.