### PR TITLE
Update to latest nfs cookbook 2.6.3

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -11,8 +11,7 @@ version          '1.0.0'
 
 depends          'base'
 depends          'kernel-modules'
-depends          'nfs', '~> 2.4.1'
-depends          'line', '< 2.0.0'
+depends          'nfs', '~> 2.6.3'
 depends          'firewall'
 
 supports         'centos', '~> 6.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,14 +26,4 @@ end
 
 include_recipe 'nfs::server'
 
-edit_resource(:sysctl_param, 'fs.nfs.nlm_tcpport') do
-  notifies :restart, "service[#{node['nfs']['service']['server']}]"
-  only_if { node['platform_version'].to_i >= 7 }
-end
-
-edit_resource(:sysctl_param, 'fs.nfs.nlm_udpport') do
-  notifies :restart, "service[#{node['nfs']['service']['server']}]"
-  only_if { node['platform_version'].to_i >= 7 }
-end
-
 include_recipe 'firewall::nfs'

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -25,22 +25,9 @@ describe 'osl-nfs::default' do
               options: %w(nlm_tcpport=32768 nlm_udpport=32768)
             )
         end
-        %w(tcp udp).each do |proto|
-          it do
-            expect(chef_run).to apply_sysctl_param("fs.nfs.nlm_#{proto}port").with(value: '32768')
-          end
-          it do
-            expect(chef_run.sysctl_param("fs.nfs.nlm_#{proto}port")).to notify('service[nfs-server]')
-          end
-        end
       when CENTOS_6
         it do
           expect(chef_run).to_not load_kernel_module('lockd')
-        end
-        %w(tcp udp).each do |proto|
-          it do
-            expect(chef_run).to_not apply_sysctl_param("fs.nfs.nlm_#{proto}port").with(value: '32768')
-          end
         end
       end
     end


### PR DESCRIPTION
Now that we're using Chef 13 globally, we can update to the latest version of
the nfs and line cookbooks. With this change, we also no longer need to edit the
sysctl_param resources for CentOS 7.