### PR TITLE
Fix duplicated lockd module resources

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,6 +1,5 @@
 source 'https://supermarket.chef.io'
 
-cookbook 'base', git: 'git@github.com:osuosl-cookbooks/base'
 cookbook 'firewall', git: 'git@github.com:osuosl-cookbooks/firewall'
 
 metadata

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,10 +9,8 @@ description      'Installs/Configures osl-nfs'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '1.0.1'
 
-depends          'base'
-depends          'kernel-modules'
-depends          'nfs', '~> 2.6.3'
 depends          'firewall'
+depends          'nfs', '~> 2.6.3'
 
 supports         'centos', '~> 6.0'
 supports         'centos', '~> 7.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -16,14 +16,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-include_recipe 'kernel-modules'
-
-kernel_module 'lockd' do
-  onboot true
-  options %w(nlm_tcpport=32768 nlm_udpport=32768)
-  only_if { node['platform_version'].to_i >= 7 }
-end
-
 include_recipe 'nfs::server'
-
 include_recipe 'firewall::nfs'

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -4,30 +4,17 @@ describe 'osl-nfs::default' do
   ALL_PLATFORMS.each do |p|
     context "#{p[:platform]} #{p[:version]}" do
       cached(:chef_run) do
-        ChefSpec::SoloRunner.new(p) do |node|
-          node.automatic['kernel']['modules'] = %w(nfs) if p == CENTOS_7
-        end.converge(described_recipe)
+        ChefSpec::SoloRunner.new(p).converge(described_recipe)
       end
       it do
         expect { chef_run }.to_not raise_error
       end
-      %w(nfs::server firewall::nfs).each do |r|
+      %w(
+        nfs::server
+        firewall::nfs
+      ).each do |r|
         it do
           expect(chef_run).to include_recipe(r)
-        end
-      end
-      case p
-      when CENTOS_7
-        it do
-          expect(chef_run).to load_kernel_module('lockd')
-            .with(
-              onboot: true,
-              options: %w(nlm_tcpport=32768 nlm_udpport=32768)
-            )
-        end
-      when CENTOS_6
-        it do
-          expect(chef_run).to_not load_kernel_module('lockd')
         end
       end
     end


### PR DESCRIPTION
We no longer need to use kernel_module to manage the lockd module. This gets
handled by the upstream . In addition, cleanup cookbook dependencies that are no
longer needed.