### PR TITLE
Chef 14 compatibility fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,11 +11,5 @@ Style/NumericLiteralPrefix:
 Metrics/LineLength:
   Max: 120
 
-Style/IfUnlessModifier:
-  MaxLineLength: 120
-
-Style/WhileUntilModifier:
-  MaxLineLength: 120
-
 Metrics/BlockLength:
   Max: 35

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,16 +1,14 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
 
-ChefSpec::Coverage.start! { add_filter 'osl-nfs' }
-
 CENTOS_7 = {
   platform: 'centos',
-  version: '7.4.1708',
+  version: '7',
 }.freeze
 
 CENTOS_6 = {
   platform: 'centos',
-  version: '6.9',
+  version: '6',
 }.freeze
 
 ALL_PLATFORMS = [
@@ -19,5 +17,5 @@ ALL_PLATFORMS = [
 ].freeze
 
 RSpec.configure do |config|
-  config.log_level = :fatal
+  config.log_level = :warn
 end


### PR DESCRIPTION
**Old ChefDK (before)**
- [x] Ensure all ChefSpec tests pass
- [x] Ensure all Inspec tests pass

**New ChefDK**
- [x] Ensure cookstyle is passing
- [x] Apply foodcritic fixes
- [x] Ensure `rake` passes
- [x] Ensure all Inspec tests pass

**Old ChefDK (after)**
- [x] Repeat all tests above using old ChefDK