### PR TITLE
Fixes for Chef 15

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,15 +1,6 @@
 AllCops:
-  Include:
-    - '**/Berksfile'
-    - '**/Cheffile'
-  Exclude:
-    - 'metadata.rb'
-
-Style/NumericLiteralPrefix:
-  EnforcedOctalStyle: zero_only
-
-Metrics/LineLength:
-  Max: 120
-
-Metrics/BlockLength:
-  Max: 35
+  TargetChefVersion: 15.latest
+ChefModernize/FoodcriticComments:
+  Enabled: true
+ChefStyle/CopyrightCommentFormat:
+  Enabled: true

--- a/Rakefile
+++ b/Rakefile
@@ -116,11 +116,6 @@ RuboCop::RakeTask.new(:style) do |task|
   task.options << '--display-cop-names'
 end
 
-desc 'Run FoodCritic (lint) tests'
-task :lint do
-  run_command('foodcritic --epic-fail any .')
-end
-
 desc 'Run RSpec (unit) tests'
 task :unit do
   run_command('rm -f Berksfile.lock')
@@ -128,6 +123,6 @@ task :unit do
 end
 
 desc 'Run all tests'
-task test: [:style, :lint, :unit]
+task test: [:style, :unit]
 
 task default: :test

--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,8 @@ require 'base64'
 require 'chef/encrypted_data_bag_item'
 require 'json'
 require 'openssl'
+require 'cookstyle'
+require 'rubocop/rake_task'
 
 snakeoil_file_path = 'test/integration/data_bags/certificates/snakeoil.json'
 encrypted_data_bag_secret_path = 'test/integration/encrypted_data_bag_secret'
@@ -90,7 +92,6 @@ file snakeoil_file_path => [
   'test/integration/data_bags/certificates',
   'test/integration/encrypted_data_bag_secret',
 ] do
-
   encrypted_data_bag_secret = Chef::EncryptedDataBagItem.load_secret(
     encrypted_data_bag_secret_path
   )
@@ -111,8 +112,8 @@ desc 'Create an Encrypted Databag Secret'
 task secret_file: encrypted_data_bag_secret_path
 
 desc 'Run RuboCop (cookstyle) tests'
-task :style do
-  run_command('cookstyle')
+RuboCop::RakeTask.new(:style) do |task|
+  task.options << '--display-cop-names'
 end
 
 desc 'Run FoodCritic (lint) tests'

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -1,9 +1,9 @@
 ---
 provisioner:
   name: chef_solo
-  #Not enforcing idempotency because several resources from the upstream nfs cookbook fail these checks
-  #enforce_idempotency: true
-  #multiple_converge: 2
+  # Not enforcing idempotency because several resources from the upstream nfs cookbook fail these checks
+  # enforce_idempotency: true
+  # multiple_converge: 2
   deprecations_as_errors: true
 
 verifier:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -9,3 +9,9 @@ suites:
   - name: homes
     run_list:
       - recipe[osl-nfs::homes]
+
+provisioner:
+  name: chef_solo
+  #enforce_idempotency: true
+  multiple_converge: 2
+  deprecations_as_errors: true

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -1,4 +1,11 @@
 ---
+provisioner:
+  name: chef_solo
+  #Not enforcing idempotency because several resources from the upstream nfs cookbook fail these checks
+  #enforce_idempotency: true
+  #multiple_converge: 2
+  deprecations_as_errors: true
+
 verifier:
   name: inspec
 
@@ -10,8 +17,3 @@ suites:
     run_list:
       - recipe[osl-nfs::homes]
 
-provisioner:
-  name: chef_solo
-  #enforce_idempotency: true
-  multiple_converge: 2
-  deprecations_as_errors: true

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,6 @@ source_url       'https://github.com/osuosl-cookbooks/osl-nfs'
 license          'Apache-2.0'
 chef_version     '>= 14.0'
 description      'Installs/Configures osl-nfs'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '1.0.4'
 
 depends          'firewall'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,8 +1,8 @@
 #
-# Cookbook Name:: osl-nfs
+# Cookbook:: osl-nfs
 # Recipe:: default
 #
-# Copyright (C) 2013 Oregon State University
+# Copyright:: 2013-2020, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/homes.rb
+++ b/recipes/homes.rb
@@ -1,8 +1,8 @@
 #
-# Cookbook Name:: osl-nfs
+# Cookbook:: osl-nfs
 # Recipe:: homes
 #
-# Copyright (C) 2013 Oregon State University
+# Copyright:: 2013-2020, Oregon State University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Currently `enforce_idempotency: true` is commented out in kitchen because the following tasks from the nfs cookbook are not idempotent:
```
- template[/etc/sysconfig/nfs]
- service[nfs-client.target]
- sysctl[fs.nfs.nlm_tcpport]
- sysctl[fs.nfs.nlm_udpport]
- service[nfs-server]
```

Everything else is as expected