### PR TITLE
Update to new osl-firewall cookbook

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,5 +1,6 @@
 source 'https://supermarket.chef.io'
 
 cookbook 'firewall', git: 'git@github.com:osuosl-cookbooks/firewall'
+cookbook 'osl-firewall', git: 'git@github.com:osuosl-cookbooks/osl-firewall'
 
 metadata

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -1,6 +1,6 @@
 ---
 provisioner:
-  name: chef_solo
+  name: chef_zero
   # Not enforcing idempotency because several resources from the upstream nfs cookbook fail these checks
   # enforce_idempotency: true
   # multiple_converge: 2
@@ -16,4 +16,3 @@ suites:
   - name: homes
     run_list:
       - recipe[osl-nfs::homes]
-

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,7 +8,7 @@ chef_version     '>= 16.0'
 description      'Installs/Configures osl-nfs'
 version          '1.3.0'
 
-depends          'firewall'
+depends          'osl-firewall'
 depends          'nfs', '~> 2.6.4'
 
 supports         'centos', '~> 7.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -16,5 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
 include_recipe 'nfs::server'
-include_recipe 'firewall::nfs'
+
+osl_firewall_nfs 'osl-nfs'

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -9,14 +9,10 @@ describe 'osl-nfs::default' do
       it do
         expect { chef_run }.to_not raise_error
       end
-      %w(
-        nfs::server
-        firewall::nfs
-      ).each do |r|
-        it do
-          expect(chef_run).to include_recipe(r)
-        end
-      end
+
+      it { expect(chef_run).to include_recipe('nfs::server') }
+
+      it { expect(chef_run).to accept_osl_firewall_nfs('osl-nfs') }
     end
   end
 end

--- a/test/integration/helpers/shared_examples.rb
+++ b/test/integration/helpers/shared_examples.rb
@@ -1,4 +1,4 @@
-describe service(os.release.to_i > 7 ? 'nfs-server' : 'nfs') do
+describe service(os.release.to_i >= 8 ? 'nfs-server' : 'nfs') do
   # Only check enabled on CentOS 7 since this service just runs and exits
   it { should be_enabled }
 end
@@ -11,24 +11,17 @@ describe service('nfs-idmapd') do
   it { should be_running }
 end
 
-version = os.release.to_i
 describe command('rpcinfo -p localhost') do
-  if version > 7
-    [
-      %w(2049 nfs),
-      %w(2049 nfs_acl),
-    ].each do |port, service|
-      its('stdout') { should match(/tcp.*#{port}.*#{service}$/) }
-    end
-  else
-    [
-      %w(2049 nfs),
-      %w(2049 nfs_acl),
-    ].each do |port, service|
-      its('stdout') { should match(/tcp.*#{port}.*#{service}$/) }
+  [
+    %w(2049 nfs),
+    %w(2049 nfs_acl),
+  ].each do |port, service|
+    its('stdout') { should match(/tcp.*#{port}.*#{service}$/) }
+    if os.release.to_i == 7
       its('stdout') { should match(/udp.*#{port}.*#{service}$/) }
     end
   end
+
   [
     %w(111 portmapper),
     %w(32765 status),

--- a/test/integration/homes/inspec/homes_spec.rb
+++ b/test/integration/homes/inspec/homes_spec.rb
@@ -8,7 +8,7 @@ describe iptables do
   %w(tcp udp).each do |proto|
     %w(111 2049 32765 32766 32767 32768 32769).each do |port|
       it do
-        should have_rule("-A nfs -s 10.162.136.0/24 -p #{proto} -m #{proto} --dport #{port} -j ACCEPT")
+        should have_rule("-A nfs -p #{proto} -m #{proto} --dport #{port} -j osl_only")
       end
     end
   end


### PR DESCRIPTION
Some other cleanup:
- `attributes` was empty, so I removed it.
- Merged duplicate logic in the Inspec tests
- Removed C6 support as `osl-firewall` does not support C6